### PR TITLE
Ignore macOS DS_Store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,8 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# MacOS
+#  The .DS_Store files (DS stands for Desktop Services) are automatically generated in macOS.
+#  They contain information about how to display folders when the user opens them.
+.DS_Store


### PR DESCRIPTION
Dear Katy,

I believe it's a good idea to ignore the automatically generated `.DS_Store` file in macOS to avoid conflicts for other macOS users.